### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
 LEDEffect	KEYWORD1
 heartbeat	KEYWORD2
-breath		KEYWORD2
-breathe		KEYWORD2
+breath	KEYWORD2
+breathe	KEYWORD2
 groupedBreathe	KEYWORD2
 breatheDelay	KEYWORD2
-flicker KEYWORD2
+flicker	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords